### PR TITLE
ci(github): remove macOS from GitHub Actions' list of OS's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
         go_version:
           - "1.16"
           - "1.17"


### PR DESCRIPTION
Overall we do nothing that needs testing across both Linux and macOS, as all
operations just call the zfs and zpool CLI tools. Hence there's no need to run
the standard unit tests which mock all CLI calls.

However, it would be useful to run the integration tests on macOS in addition to
Linux, but I'm not aware of a way to do this with the GitHub-hosted Actions
Runners, as on macOS a full system reboot is required after installing OpenZFS.
On Ubuntu a reboot is not required however.